### PR TITLE
fix: fetch submodule info

### DIFF
--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -15,6 +15,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  submodules: recursive
 
             - name: Cherry pick
               id: cherry-pick


### PR DESCRIPTION
workflow wasn't fetching submodule during checkout