### PR TITLE
fix: trim original PR title

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,6 @@ export async function run(): Promise<void> {
         const targetBranch = core.getInput('target-branch')
         const submodulesTargetBranch = core.getInput('submodules-target-branch')
         const githubToken = core.getInput('pr-creator-token')
-        const prTitleSuffix = core.getInput('pr-title-suffix').trim()
         let prAssignee = core.getInput('pr-assignee')
         if (prAssignee === '' && mergedPR.assignee != null) {
             // Use the assignee of the original PR as the assignee of the cherry-pick
@@ -86,6 +85,7 @@ export async function run(): Promise<void> {
         )
 
         const originalPrTitle = mergedPR.title.trim()
+        const prTitleSuffix = core.getInput('pr-title-suffix').trim()
         const prTitle = prTitleSuffix.length > 0 ? `${originalPrTitle} ${prTitleSuffix}` : originalPrTitle
         const resultPrNumber = await createPullRequest(
             githubToken,

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,8 @@ export async function run(): Promise<void> {
             shouldFastForwardSubmodules
         )
 
-        const prTitle = prTitleSuffix.length > 0 ? `${mergedPR.title} ${prTitleSuffix}` : mergedPR.title
+        const originalPrTitle = mergedPR.title.trim()
+        const prTitle = prTitleSuffix.length > 0 ? `${originalPrTitle} ${prTitleSuffix}` : originalPrTitle
         const resultPrNumber = await createPullRequest(
             githubToken,
             mergedPR,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In the iOS repo the issue has returned that a cherry-pick's PR title has a trailing whitespace character.

### Causes (Optional)

Not sure, after the last fix https://github.com/wireapp/action-auto-cherry-pick/commit/064d58262398b2dbfe56f61107370c3192fbec29

### Solutions

Try to add another trim() call.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
